### PR TITLE
Skip GTFS validator update check

### DIFF
--- a/src/main/java/no/entur/damu/gtfs/validator/GtfsValidator.java
+++ b/src/main/java/no/entur/damu/gtfs/validator/GtfsValidator.java
@@ -71,9 +71,11 @@ public class GtfsValidator {
       "gtfs-validation-output-" + datasetReferential
     );
 
-    ValidationRunnerConfig.Builder builder = ValidationRunnerConfig.builder();
-    builder.setGtfsSource(tempGtfsFile.toUri());
-    builder.setOutputDirectory(gtfsValidationReportsDirectory);
+    ValidationRunnerConfig.Builder builder = ValidationRunnerConfig
+      .builder()
+      .setGtfsSource(tempGtfsFile.toUri())
+      .setOutputDirectory(gtfsValidationReportsDirectory)
+      .setSkipValidatorUpdate(true);
     ValidationRunner runner = new ValidationRunner(
       new VersionResolver(ApplicationType.WEB)
     );


### PR DESCRIPTION
Prevent the GTFS validator library from making a network call to check if an updated version is available:
Otherwise the call timeout with the following exception and delay processing:
```
Error obtaining release version
java.util.concurrent.TimeoutException: Waited 5000 milliseconds (plus 157756 nanoseconds delay) for SettableFuture@6399ccc3[status=PENDING]
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:539)
	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:122)
	at org.mobilitydata.gtfsvalidator.util.VersionResolver.getVersionInfoWithTimeout(VersionResolver.java:63)
	at org.mobilitydata.gtfsvalidator.runner.ValidationRunner.run(ValidationRunner.java:84)
	at no.entur.damu.gtfs.validator.GtfsValidator.validate(GtfsValidator.java:80) 
```