### PR TITLE
Remove unused Maven dependencies and dead config

### DIFF
--- a/helm/damu/templates/configmap.yaml
+++ b/helm/damu/templates/configmap.yaml
@@ -20,7 +20,6 @@ data:
     camel.main.name=damu
     camel.main.stream-caching-enabled=false
     camel.main.stream-caching-spool-enabled=true
-    camel.dataformat.jackson.module-refs=jacksonJavaTimeModule
     # the Camel shutdown timeout must be shorter than the Kubernetes terminationGracePeriod
     damu.shutdown.timeout=25
     damu.camel.redelivery.max=0
@@ -51,7 +50,6 @@ data:
     logging.level.no.entur=INFO
     logging.level.no.entur.damu=INFO
     logging.level.org.apache=INFO
-    logging.level.org.apache.camel.component.http.HttpComponent=WARN
 
 
 kind: ConfigMap

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,11 @@
         <java.version>21</java.version>
         <camel.version>4.8.9</camel.version>
         <entur.helpers.version>5.50.0</entur.helpers.version>
-        <commons-io.version>2.11.0</commons-io.version>
         <netex-gtfs-converter-java.version>3.0.0</netex-gtfs-converter-java.version>
         <zt-zip.version>1.17</zt-zip.version>
         <commons-csv.version>1.14.1</commons-csv.version>
         <prettier-java.version>2.1.0</prettier-java.version>
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
-        <zt-zip.version>1.17</zt-zip.version>
         <plugin.prettier.goal>write</plugin.prettier.goal>
 
         <!-- empty argLine property, the value is set up by Jacoco during unit tests execution -->
@@ -122,27 +120,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-zipfile-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-file-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-jaxb-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-platform-http-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-http-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-openapi-java-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
@@ -151,20 +129,10 @@
 
         <!-- Other -->
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-zip</artifactId>
             <version>${zt-zip.version}</version>
             <type>jar</type>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -21,7 +21,6 @@ server.port=28080
 camel.main.name=damu
 camel.main.stream-caching-enabled=false
 camel.main.stream-caching-spool-enabled=true
-camel.dataformat.jackson.module-refs=jacksonJavaTimeModule
 damu.camel.redelivery.max=0
 
 # Blob store


### PR DESCRIPTION
## Summary
- Remove 7 unused Maven dependencies: `camel-zipfile-starter`, `camel-jaxb-starter`, `camel-platform-http-starter`, `camel-http-starter`, `camel-openapi-java-starter`, `jackson-datatype-jsr310`, and `jakarta.ws.rs-api`
- Remove orphan property `commons-io.version` and duplicate `zt-zip.version` declaration
- Remove dead config lines: `jacksonJavaTimeModule` (no marshal/unmarshal in any route) and Camel HTTP component log level (component removed)

## Verification
Each dependency was verified unused by searching the codebase for relevant imports, Camel endpoints, and configuration references. `jackson-datatype-jsr310` was confirmed unused — the `jacksonJavaTimeModule` Camel config existed but no route uses Jackson marshal/unmarshal, and PubSub messages are plain strings.

## Test plan
- [x] Full test suite passes (31 tests, 0 failures)