### PR TITLE
Upgrade Apache Camel to 4.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </scm>
     <properties>
         <java.version>21</java.version>
-        <camel.version>4.8.9</camel.version>
+        <camel.version>4.18.2</camel.version>
         <entur.helpers.version>5.50.0</entur.helpers.version>
         <netex-gtfs-converter-java.version>3.0.1</netex-gtfs-converter-java.version>
         <zt-zip.version>1.17</zt-zip.version>
@@ -185,6 +185,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
+            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/entur/damu/config/GooglePubsubHeaderFilterConfig.java
+++ b/src/main/java/no/entur/damu/config/GooglePubsubHeaderFilterConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.entur.damu.config;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.google.pubsub.GooglePubsubComponent;
+import org.apache.camel.component.google.pubsub.GooglePubsubHeaderFilterStrategy;
+import org.apache.camel.spi.ComponentCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Restricts outbound Google PubSub message attributes to the explicit attribute map curated by
+ * {@code BaseRouteBuilder}.
+ *
+ * <p>Since Camel 4.x the PubSub producer copies every non-filtered Camel header into the published
+ * message attributes (in addition to the explicit {@code GooglePubsubConstants.ATTRIBUTES} map).
+ * That would leak internal headers such as {@code RutebankenFileHandle} and
+ * {@code TIMETABLE_DATASET_FILE} to downstream consumers. This strategy filters out all Camel
+ * headers on the way out, so only the whitelisted attribute map is published. Inbound filtering
+ * keeps the component default behaviour.
+ */
+@Configuration
+public class GooglePubsubHeaderFilterConfig {
+
+  @Bean
+  ComponentCustomizer googlePubsubHeaderFilterCustomizer() {
+    return ComponentCustomizer
+      .builder(GooglePubsubComponent.class)
+      .build(component ->
+        component.setHeaderFilterStrategy(
+          new OutboundFilteringHeaderFilterStrategy()
+        )
+      );
+  }
+
+  /**
+   * Filters out all Camel headers when producing to PubSub. Outbound attributes are set explicitly
+   * through {@code GooglePubsubConstants.ATTRIBUTES}, so no header should be mapped automatically.
+   */
+  static class OutboundFilteringHeaderFilterStrategy
+    extends GooglePubsubHeaderFilterStrategy {
+
+    @Override
+    public boolean applyFilterToCamelHeaders(
+      String headerName,
+      Object headerValue,
+      Exchange exchange
+    ) {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
Bump camel.version from 4.8.9 to 4.18.2 and pin camel-test-spring-junit5 to ${camel.version}. Add GooglePubsubHeaderFilterConfig so the 4.x PubSub producer stops copying internal Camel headers (RutebankenFileHandle, TIMETABLE_DATASET_FILE) into published message attributes; only the curated ATTRIBUTES map is published.