### PR TITLE
Improved handling of conversion exceptions

### DIFF
--- a/src/main/java/no/entur/damu/routes/export/GtfsExportQueueRouteBuilder.java
+++ b/src/main/java/no/entur/damu/routes/export/GtfsExportQueueRouteBuilder.java
@@ -145,7 +145,7 @@ public class GtfsExportQueueRouteBuilder extends BaseRouteBuilder {
         );
         exchange
           .getIn()
-          .setBody(gtfsExporter.convertTimetablesToGtfs(timetableDataset));
+          .setBody(convertToGtfs(gtfsExporter, timetableDataset, codespace));
       })
       .log(LoggingLevel.INFO, correlation() + "Dataset processing complete")
       .routeId("convert-to-gtfs");
@@ -176,5 +176,34 @@ public class GtfsExportQueueRouteBuilder extends BaseRouteBuilder {
     from("direct:notifyMarduk")
       .to("google-pubsub:{{damu.pubsub.project.id}}:DamuExportGtfsStatusQueue")
       .routeId("notify-marduk");
+  }
+
+  /**
+   * Run the NeTEx-to-GTFS conversion, ensuring any failure surfaces as a
+   * {@link GtfsExportException}.
+   * <p>
+   * A failure inside the converter is deterministic for a given dataset (e.g. the
+   * {@code IndexOutOfBoundsException} thrown for journey patterns whose stop-point
+   * {@code order} values are not a dense {@code 1..N} sequence): retrying cannot help.
+   * Wrapping it as a {@link GtfsExportException} routes it through the
+   * {@code onException(GtfsExportException.class)} handler, which marks the export failed and
+   * lets the Pub/Sub message be acknowledged, instead of letting an unexpected exception
+   * escape unhandled and have the message redelivered until retention expires.
+   */
+  static InputStream convertToGtfs(
+    GtfsExporter gtfsExporter,
+    InputStream timetableDataset,
+    String codespace
+  ) {
+    try {
+      return gtfsExporter.convertTimetablesToGtfs(timetableDataset);
+    } catch (GtfsExportException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new GtfsExportException(
+        "GTFS conversion failed for codespace " + codespace,
+        e
+      );
+    }
   }
 }

--- a/src/test/java/no/entur/damu/routes/export/ConvertToGtfsFailureTest.java
+++ b/src/test/java/no/entur/damu/routes/export/ConvertToGtfsFailureTest.java
@@ -30,13 +30,14 @@ class ConvertToGtfsFailureTest {
       "Index 5 out of bounds for length 5"
     );
     when(exporter.convertTimetablesToGtfs(any())).thenThrow(cause);
+    InputStream timetableDataset = InputStream.nullInputStream();
 
     GtfsExportException thrown = assertThrows(
       GtfsExportException.class,
       () ->
         GtfsExportQueueRouteBuilder.convertToGtfs(
           exporter,
-          InputStream.nullInputStream(),
+          timetableDataset,
           "FLT"
         )
     );
@@ -49,13 +50,14 @@ class ConvertToGtfsFailureTest {
     GtfsExporter exporter = mock(GtfsExporter.class);
     GtfsExportException original = new GtfsExportException("boom");
     when(exporter.convertTimetablesToGtfs(any())).thenThrow(original);
+    InputStream timetableDataset = InputStream.nullInputStream();
 
     GtfsExportException thrown = assertThrows(
       GtfsExportException.class,
       () ->
         GtfsExportQueueRouteBuilder.convertToGtfs(
           exporter,
-          InputStream.nullInputStream(),
+          timetableDataset,
           "FLT"
         )
     );

--- a/src/test/java/no/entur/damu/routes/export/ConvertToGtfsFailureTest.java
+++ b/src/test/java/no/entur/damu/routes/export/ConvertToGtfsFailureTest.java
@@ -1,0 +1,65 @@
+package no.entur.damu.routes.export;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import org.entur.netex.gtfs.export.GtfsExporter;
+import org.entur.netex.gtfs.export.exception.GtfsExportException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the conversion-failure handling in {@link GtfsExportQueueRouteBuilder}.
+ *
+ * <p>A failure inside the converter (e.g. the {@code IndexOutOfBoundsException} thrown for
+ * NeTEx journey patterns whose stop-point {@code order} values are not a dense {@code 1..N}
+ * sequence) must surface as a {@link GtfsExportException} so that the route's
+ * {@code onException(GtfsExportException.class)} handler marks the export failed and the
+ * Pub/Sub message is acknowledged, instead of being redelivered until retention expires.
+ */
+class ConvertToGtfsFailureTest {
+
+  @Test
+  void nonGtfsExportExceptionIsWrappedAsGtfsExportException() {
+    GtfsExporter exporter = mock(GtfsExporter.class);
+    IndexOutOfBoundsException cause = new IndexOutOfBoundsException(
+      "Index 5 out of bounds for length 5"
+    );
+    when(exporter.convertTimetablesToGtfs(any())).thenThrow(cause);
+
+    GtfsExportException thrown = assertThrows(
+      GtfsExportException.class,
+      () ->
+        GtfsExportQueueRouteBuilder.convertToGtfs(
+          exporter,
+          InputStream.nullInputStream(),
+          "FLT"
+        )
+    );
+
+    assertInstanceOf(IndexOutOfBoundsException.class, thrown.getCause());
+  }
+
+  @Test
+  void gtfsExportExceptionIsNotDoubleWrapped() {
+    GtfsExporter exporter = mock(GtfsExporter.class);
+    GtfsExportException original = new GtfsExportException("boom");
+    when(exporter.convertTimetablesToGtfs(any())).thenThrow(original);
+
+    GtfsExportException thrown = assertThrows(
+      GtfsExportException.class,
+      () ->
+        GtfsExportQueueRouteBuilder.convertToGtfs(
+          exporter,
+          InputStream.nullInputStream(),
+          "FLT"
+        )
+    );
+
+    assertSame(original, thrown);
+  }
+}


### PR DESCRIPTION
Wrap the convertTimetablesToGtfs call so any non-GtfsExportException is rethrown as a GtfsExportException. Failure during conversion now flows through the existing handler (log, notify Marduk "failed", handled=true), so the message is acknowledged. Scoped to the conversion step only, leaving download/upload retry behaviour unchanged.