### PR TITLE
Set maxDeliveryAttempts on the GtfsRouteDispatcherTopic consumer

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -9,17 +9,19 @@ Damu is a Spring Boot application that converts NeTEx (Network Timetable Exchang
 ### Technology Stack
 - **Java 21** - Core language
 - **Spring Boot** - Application framework
-- **Apache Camel 4.8.9** - Integration framework and routing
+- **Apache Camel 4.18.2** - Integration framework and routing (see pom.xml for the current version)
 - **Google Cloud Platform**:
   - Cloud Storage (GCS) - File storage
   - Pub/Sub - Messaging
 - **Maven** - Build tool
 
 ### Key Dependencies
-- `netex-gtfs-converter-java` (v2.1.105) - Core NeTEx to GTFS conversion
-- `gtfs-validator-main` (v6.0.0) - GTFS validation
-- `entur-helpers` (v5.47.0) - Google Cloud integration utilities
-- `zt-zip` (v1.17) - ZIP file handling
+- `netex-gtfs-converter-java` - Core NeTEx to GTFS conversion
+- `gtfs-validator-main` - GTFS validation
+- `entur-helpers` - Google Cloud integration utilities
+- `zt-zip` - ZIP file handling
+
+Versions live in pom.xml; do not trust versions written in this file.
 
 ### Integration Flow
 1. **Trigger**: Chouette or Uttu completes a NeTEx export
@@ -233,4 +235,4 @@ Licensed under EUPL-1.2 (see LICENSE.txt)
 
 - **Repository**: https://github.com/entur/damu
 - **CI**: https://circleci.com/gh/entur/damu/tree/master
-- **Parent POM**: org.entur.ror:superpom:4.9.0
+- **Parent POM**: org.entur.ror:superpom (version in pom.xml)

--- a/src/main/java/no/entur/damu/routes/GtfsRouteDispatcher.java
+++ b/src/main/java/no/entur/damu/routes/GtfsRouteDispatcher.java
@@ -3,8 +3,6 @@ package no.entur.damu.routes;
 import static no.entur.damu.Constants.*;
 
 import org.apache.camel.LoggingLevel;
-import org.apache.camel.component.google.pubsub.GooglePubsubConstants;
-import org.apache.camel.component.google.pubsub.consumer.GooglePubsubAcknowledge;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,20 +12,10 @@ public class GtfsRouteDispatcher extends BaseRouteBuilder {
   public void configure() throws Exception {
     super.configure();
 
-    onException(Exception.class)
-      .process(exchange -> {
-        GooglePubsubAcknowledge acknowledge = exchange
-          .getIn()
-          .getHeader(
-            GooglePubsubConstants.GOOGLE_PUBSUB_ACKNOWLEDGE,
-            GooglePubsubAcknowledge.class
-          );
-        acknowledge.ack(exchange);
-      })
-      .handled(true);
-
+    // mirrors dead_letter_policy.max_delivery_attempts in marduk terraform/pubsub.tf;
+    // attempt 5 is nacked unprocessed to trigger DLQ forwarding
     from(
-      "google-pubsub:{{marduk.pubsub.project.id}}:GtfsRouteDispatcherTopic?synchronousPull=true&ackMode=AUTO"
+      "google-pubsub:{{marduk.pubsub.project.id}}:GtfsRouteDispatcherTopic?synchronousPull=true&ackMode=AUTO&maxDeliveryAttempts=5"
     )
       .choice()
       .when(

--- a/src/test/java/no/entur/damu/routes/NetexToGtfsConversionIntegrationTest.java
+++ b/src/test/java/no/entur/damu/routes/NetexToGtfsConversionIntegrationTest.java
@@ -40,8 +40,10 @@ import no.entur.damu.stop.StopPlaceFetcher;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.Route;
 import org.apache.camel.builder.AdviceWith;
 import org.apache.camel.component.google.pubsub.GooglePubsubConstants;
+import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.entur.netex.gtfs.export.stop.StopAreaRepositoryFactory;
 import org.junit.jupiter.api.Test;
@@ -351,6 +353,34 @@ class NetexToGtfsConversionIntegrationTest
     assertTrue(
       aggregatedBasicContent.length > 0,
       "Basic aggregated GTFS file must be non-empty"
+    );
+  }
+
+  /**
+   * Pins the explicit maxDeliveryAttempts on the consumer endpoint. Without
+   * it, Camel 4.18 auto-fetches the value from the subscription at startup,
+   * which fails with PERMISSION_DENIED in real environments (the emulator
+   * allows it, so removal would pass CI silently).
+   */
+  @Test
+  void gtfsRouteDispatcherConsumerHasExplicitMaxDeliveryAttempts() {
+    context.start();
+
+    GooglePubsubEndpoint endpoint = context
+      .getRoutes()
+      .stream()
+      .map(Route::getEndpoint)
+      .filter(GooglePubsubEndpoint.class::isInstance)
+      .map(GooglePubsubEndpoint.class::cast)
+      .filter(e -> "GtfsRouteDispatcherTopic".equals(e.getDestinationName()))
+      .findFirst()
+      .orElseThrow();
+
+    assertTrue(endpoint.isMaxDeliveryAttemptsExplicitlySet());
+    assertEquals(
+      5,
+      endpoint.getMaxDeliveryAttempts(),
+      "must match dead_letter_policy.max_delivery_attempts in marduk terraform/pubsub.tf"
     );
   }
 }


### PR DESCRIPTION
Camel 4.18 tries to auto-fetch it from the subscription's dead-letter policy at startup, which fails with PERMISSION_DENIED and disables enforcement. Set it explicitly to the policy value so poison messages are nacked to the DLQ without reprocessing. Remove the onException ack handler: GOOGLE_PUBSUB_ACKNOWLEDGE is only set with ackMode=NONE, so it always threw NPE and failures were nacked anyway; failing naturally gives the same retries plus dead-lettering. Pin the endpoint option with a test, since the pubsub emulator allows the auto-fetch and removal would pass CI silently.