### PR TITLE
Migrate logback conditional off the deprecated janino form

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,10 @@
   -->
 
 <configuration>
-    <if condition='property("env").contains("dev")'>
+    <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
+        <expression>propertyContains("env", "dev")</expression>
+    </condition>
+    <if>
     <then>
         <include resource="org/springframework/boot/logging/logback/base.xml" />
     </then>


### PR DESCRIPTION
The condition attribute logged two deprecation errors at every boot. The replacement is a condition element preceding the if, using the new property expression language; propertyContains keeps the exact janino semantics. Verified both branches attach the right appenders.