### PR TITLE
Upgrade to Spring Boot 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Damu is a Spring Boot application that converts NeTEx (Network Timetable Exchang
 ### Technology Stack
 - **Java 21** - Core language
 - **Spring Boot** - Application framework
-- **Apache Camel 4.18.2** - Integration framework and routing (see pom.xml for the current version)
+- **Apache Camel** - Integration framework and routing (see pom.xml for the current version)
 - **Google Cloud Platform**:
   - Cloud Storage (GCS) - File storage
   - Pub/Sub - Messaging
@@ -179,7 +179,6 @@ Spring Boot Actuator provides health checks and metrics:
 Workflow defined in `.github/workflows/push.yml`:
 - Build and test on push
 - Code formatting validation
-- CircleCI integration (legacy)
 
 ## Code Quality
 
@@ -190,7 +189,6 @@ Workflow defined in `.github/workflows/push.yml`:
 
 ### Security
 - OWASP Dependency Check suppression configuration
-- CodeQL security scanning support
 
 ## Related Projects
 
@@ -234,5 +232,4 @@ Licensed under EUPL-1.2 (see LICENSE.txt)
 ## Links
 
 - **Repository**: https://github.com/entur/damu
-- **CI**: https://circleci.com/gh/entur/damu/tree/master
 - **Parent POM**: org.entur.ror:superpom (version in pom.xml)

--- a/helm/damu/templates/configmap.yaml
+++ b/helm/damu/templates/configmap.yaml
@@ -38,10 +38,10 @@ data:
     # Actuator
     management.server.port={{ .Values.common.service.internalPort }}
     management.endpoints.access.default=none
-    management.endpoint.info.enabled=true
-    management.endpoint.health.enabled=true
+    management.endpoint.info.access=unrestricted
+    management.endpoint.health.access=unrestricted
     management.endpoint.health.group.readiness.include=readinessState
-    management.endpoint.prometheus.enabled=true
+    management.endpoint.prometheus.access=unrestricted
     management.endpoints.web.exposure.include=info,health,prometheus
     management.health.pubsub.enabled=false
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>5.6.0</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>no.entur.damu</groupId>
@@ -24,8 +24,9 @@
     </scm>
     <properties>
         <java.version>21</java.version>
-        <camel.version>4.18.3</camel.version>
-        <entur.helpers.version>5.50.0</entur.helpers.version>
+        <camel.version>4.21.0</camel.version>
+        <entur.helpers.version>7.2.0</entur.helpers.version>
+        <spring-cloud-gcp-dependencies.version>7.4.10</spring-cloud-gcp-dependencies.version>
         <netex-gtfs-converter-java.version>3.0.4</netex-gtfs-converter-java.version>
         <zt-zip.version>1.17</zt-zip.version>
         <commons-csv.version>1.14.1</commons-csv.version>
@@ -40,6 +41,28 @@
     <dependencyManagement>
         <dependencies>
 
+            <!--
+              Must precede spring-cloud-gcp-dependencies, which pins opentelemetry-api to an older
+              version than the rest of the opentelemetry modules resolve to. First declaration wins.
+            -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!--
+              entur-helpers still pins spring-cloud-gcp 5.11.3, which references Boot 3 classes that
+              no longer exist. Remove this once helpers ships a Boot 4 compatible version.
+            -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>${spring-cloud-gcp-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.apache.camel.springboot</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
@@ -64,20 +87,6 @@
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>storage-gcp-gcs</artifactId>
             <version>${entur.helpers.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec-http2</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-lite</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.entur</groupId>
@@ -152,13 +161,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!--Janino is required by Logback for conditional processing in logback.xml-->
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
@@ -168,13 +170,24 @@
 
         <!-- testing -->
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-resttestclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Provides RestTemplateBuilder used by TestRestTemplate -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>gcloud</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-gcloud</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/entur/damu/App.java
+++ b/src/main/java/no/entur/damu/App.java
@@ -26,13 +26,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 /**
  * A spring-boot application that includes a Camel route builder to set up the Camel context.
  */
-@SpringBootApplication(exclude = { UserDetailsServiceAutoConfiguration.class })
+@SpringBootApplication
 @Import({ GcsBlobStoreRepositoryConfig.class, GooglePubSubConfig.class })
 public class App extends RouteBuilder {
 

--- a/src/test/java/no/entur/damu/DamuRouteBuilderIntegrationTestBase.java
+++ b/src/test/java/no/entur/damu/DamuRouteBuilderIntegrationTestBase.java
@@ -38,7 +38,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PubSubEmulatorContainer;
+import org.testcontainers.gcloud.PubSubEmulatorContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 

--- a/src/test/java/no/entur/damu/TestApp.java
+++ b/src/test/java/no/entur/damu/TestApp.java
@@ -20,11 +20,10 @@ package no.entur.damu;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+@SpringBootApplication
 @ComponentScan(
   excludeFilters = {
     @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = App.class),

--- a/src/test/java/no/entur/damu/actuator/ActuatorHealthEndpointIntegrationTest.java
+++ b/src/test/java/no/entur/damu/actuator/ActuatorHealthEndpointIntegrationTest.java
@@ -20,28 +20,46 @@ package no.entur.damu.actuator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Map;
 import no.entur.damu.TestApp;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PubSubEmulatorContainer;
+import org.testcontainers.gcloud.PubSubEmulatorContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * The main purpose of this test is to check that the HTTP server is up and running.
+ * Verifies that the actuator endpoints exposed in production are reachable without
+ * authentication, so that the Kubernetes probes and the Prometheus scrape keep working.
  */
 @SpringBootTest(
   classes = TestApp.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  // mirrors the actuator configuration in helm/damu/templates/configmap.yaml
+  properties = {
+    "management.endpoints.access.default=none",
+    "management.endpoint.info.access=unrestricted",
+    "management.endpoint.health.access=unrestricted",
+    "management.endpoint.health.group.readiness.include=readinessState",
+    "management.endpoint.prometheus.access=unrestricted",
+    "management.endpoints.web.exposure.include=info,health,prometheus",
+    "management.endpoints.web.exposure.exclude=",
+  }
 )
+@AutoConfigureTestRestTemplate
 @ActiveProfiles(
   { "test", "default", "in-memory-blobstore", "google-pubsub-autocreate" }
 )
@@ -66,19 +84,24 @@ class ActuatorHealthEndpointIntegrationTest {
       "camel.component.google-pubsub.endpoint",
       pubsubEmulator::getEmulatorEndpoint
     );
-    registry.add("management.endpoints.web.exposure.include", () -> "health");
-    registry.add("management.endpoints.web.exposure.exclude", () -> "");
-    registry.add("management.endpoint.health.enabled", () -> "true");
-    registry.add("management.endpoint.health.show-details", () -> "always");
   }
 
   @Autowired
   private TestRestTemplate restTemplate;
 
-  @Test
-  void testHealthEndpointIsAccessible() {
-    ResponseEntity<String> response = restTemplate.getForEntity(
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      "/actuator/info",
       "/actuator/health",
+      "/actuator/health/liveness",
+      "/actuator/health/readiness",
+      "/actuator/prometheus",
+    }
+  )
+  void testExposedEndpointIsAccessible(String path) {
+    ResponseEntity<String> response = restTemplate.getForEntity(
+      path,
       String.class
     );
 
@@ -86,16 +109,38 @@ class ActuatorHealthEndpointIntegrationTest {
     assertNotNull(response.getBody());
   }
 
-  @Test
-  void testHealthEndpointReturnsUpStatus() {
-    ResponseEntity<String> response = restTemplate.getForEntity(
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
       "/actuator/health",
+      "/actuator/health/liveness",
+      "/actuator/health/readiness",
+    }
+  )
+  void testHealthEndpointReturnsUpStatus(String path) {
+    ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+      path,
+      HttpMethod.GET,
+      null,
+      new ParameterizedTypeReference<>() {}
+    );
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    Map<String, Object> body = response.getBody();
+    assertNotNull(body);
+    assertEquals("UP", body.get("status"));
+  }
+
+  @Test
+  void testPrometheusEndpointReturnsMetrics() {
+    ResponseEntity<String> response = restTemplate.getForEntity(
+      "/actuator/prometheus",
       String.class
     );
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     String body = response.getBody();
     assertNotNull(body);
-    assertTrue(body.contains("\"status\":\"UP\""));
+    assertTrue(body.contains("# HELP"), body);
   }
 }

--- a/src/test/java/no/entur/damu/netex/EnturGtfsExportTest.java
+++ b/src/test/java/no/entur/damu/netex/EnturGtfsExportTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
@@ -32,6 +33,7 @@ import org.entur.netex.gtfs.export.GtfsExporter;
 import org.entur.netex.gtfs.export.stop.DefaultStopAreaRepositoryFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.zeroturnaround.zip.ZipUtil;
 
 /**
@@ -40,7 +42,7 @@ import org.zeroturnaround.zip.ZipUtil;
 class EnturGtfsExportTest {
 
   @Test
-  void testEnturExport() throws IOException {
+  void testEnturExport(@TempDir Path tempDir) throws IOException {
     DefaultStopAreaRepositoryFactory factory =
       new DefaultStopAreaRepositoryFactory();
     factory.refreshStopAreaRepository(
@@ -60,7 +62,7 @@ class EnturGtfsExportTest {
       netexTimetableDataset
     );
 
-    File gtfsFile = new File("export-gtfs.zip");
+    File gtfsFile = tempDir.resolve("export-gtfs.zip").toFile();
     java.nio.file.Files.copy(
       exportedGtfs,
       gtfsFile.toPath(),


### PR DESCRIPTION
The Boot 3 security auto-configuration names no longer compile, and damu has no spring-security on the classpath, so the excludes are dropped instead of relocated.

camel-spring-boot 4.18.x is built against Boot 3.5, so Camel moves too.

Boot 4 enables the liveness and readiness probe groups by default, which is why the actuator test can assert those paths without setting probes.enabled.