### PR TITLE
jdk 25 and spring boot 4.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,6 +31,7 @@ jobs:
       - run: mvn verify -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
       - uses: actions/upload-artifact@v7.0.1
         with:
+          name: artifact
           path: target/*.jar
       - name: Sonar Scan
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,15 +12,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5.1.0
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v5.7.0
         with:
-          java-version: 21.0.5+11
+          java-version: 25.0.4
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-maven-
             ${{ runner.os }}-
       - run: mvn verify -P prettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
-      - uses: actions/upload-artifact@v5.0.0
+      - uses: actions/upload-artifact@v7.0.1
         with:
           path: target/*.jar
       - name: Sonar Scan
@@ -49,6 +49,26 @@ jobs:
                   -Dsonar.projectName=${SONAR_PROJECT_NAME} \
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
+  docker-smoke:
+    needs: [maven-verify]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          name: artifact
+          path: target
+      - run: docker build -t damu:smoke .
+      # Nothing else in CI runs the image. Reaching Spring's startup line proves the JRE loaded the
+      # application bytecode; it then fails on config that only exists in the cluster, which is fine.
+      # A wrong class file version or an unusable base image never gets that far.
+      - run: |
+          timeout 180 docker run --rm damu:smoke 2>&1 | tee smoke.log || true
+          grep -q "using Java" smoke.log
+
   docker-build:
     if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [maven-verify]
@@ -57,7 +77,7 @@ jobs:
       build_artifact_name: artifact
       build_artifact_path: target
   docker-push:
-    needs: [docker-build]
+    needs: [docker-build, docker-smoke]
     uses: entur/gha-docker/.github/workflows/push.yml@v1.11.0
 
   helm-lint:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Damu is a Spring Boot application that converts NeTEx (Network Timetable Exchang
 ## Architecture
 
 ### Technology Stack
-- **Java 21** - Core language
+- **Java 25** - Core language
 - **Spring Boot** - Application framework
 - **Apache Camel** - Integration framework and routing (see pom.xml for the current version)
 - **Google Cloud Platform**:
@@ -88,7 +88,7 @@ Multiple blob store configurations support different environments:
 ## Development Setup
 
 ### Prerequisites
-- Java 21 JDK
+- Java 25 JDK
 - Maven 3.6+
 - Docker (optional, for containerized deployment)
 - Google Cloud SDK (for GCS/Pub/Sub integration)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bellsoft/liberica-openjre-alpine:21.0.12 AS builder
+FROM bellsoft/liberica-openjre-alpine:25.0.4 AS builder
 WORKDIR /builder
 COPY target/*-SNAPSHOT.jar application.jar
 RUN java -Djarmode=tools  -jar application.jar extract --layers --destination extracted
 
-FROM bellsoft/liberica-openjre-alpine:21.0.12
+FROM bellsoft/liberica-openjre-alpine:25.0.4
 RUN apk update && apk upgrade && apk add --no-cache tini
 WORKDIR /deployments
 RUN addgroup appuser && adduser --disabled-password appuser --ingroup appuser

--- a/helm/damu/env/values-kub-ent-dev.yaml
+++ b/helm/damu/env/values-kub-ent-dev.yaml
@@ -5,7 +5,7 @@ common:
     data:
       JDK_JAVA_OPTIONS: -server -Xmx15000m -Xss512k -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
         -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:ActiveProcessorCount=2
-        -Dspring.config.location=/etc/application-config/application.properties
+        -XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dspring.config.location=/etc/application-config/application.properties
         -Dfile.encoding=UTF-8
 
 damu:

--- a/helm/damu/env/values-kub-ent-prd.yaml
+++ b/helm/damu/env/values-kub-ent-prd.yaml
@@ -5,7 +5,7 @@ common:
     data:
       JDK_JAVA_OPTIONS: -server -Xmx15000m -Xss512k -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
         -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:ActiveProcessorCount=2
-        -Dspring.config.location=/etc/application-config/application.properties
+        -XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dspring.config.location=/etc/application-config/application.properties
         -Dfile.encoding=UTF-8
 
 damu:

--- a/helm/damu/env/values-kub-ent-tst.yaml
+++ b/helm/damu/env/values-kub-ent-tst.yaml
@@ -5,7 +5,7 @@ common:
     data:
       JDK_JAVA_OPTIONS: -server -Xmx15000m -Xss512k -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
         -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:ActiveProcessorCount=2
-        -Dspring.config.location=/etc/application-config/application.properties
+        -XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dspring.config.location=/etc/application-config/application.properties
         -Dfile.encoding=UTF-8
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>6.5.0</version>
+        <version>7.0.0</version>
     </parent>
 
     <groupId>no.entur.damu</groupId>
@@ -23,10 +23,9 @@
         <developerConnection>scm:git:ssh://git@github.com:entur/damu.git</developerConnection>
     </scm>
     <properties>
-        <java.version>21</java.version>
         <camel.version>4.21.0</camel.version>
         <entur.helpers.version>7.2.0</entur.helpers.version>
-        <spring-cloud-gcp-dependencies.version>7.4.10</spring-cloud-gcp-dependencies.version>
+        <spring-cloud-gcp-dependencies.version>8.1.0</spring-cloud-gcp-dependencies.version>
         <netex-gtfs-converter-java.version>3.0.4</netex-gtfs-converter-java.version>
         <zt-zip.version>1.17</zt-zip.version>
         <commons-csv.version>1.14.1</commons-csv.version>
@@ -42,8 +41,9 @@
         <dependencies>
 
             <!--
-              Must precede spring-cloud-gcp-dependencies, which pins opentelemetry-api to an older
-              version than the rest of the opentelemetry modules resolve to. First declaration wins.
+              Keeps the whole opentelemetry graph on one version when spring-cloud-gcp and Spring Boot
+              disagree on it. First declaration wins, so this pins every module to Boot's
+              opentelemetry.version.
             -->
             <dependency>
                 <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
spring-cloud-gcp 8.1.0 is the same code as 7.4.10 rebuilt against Spring Boot 4; 7.4.10 compiles against spring-boot-autoconfigure 3.5.3. The chart gains the JDK 25 native-access and Unsafe flags, guarded by IgnoreUnrecognizedVMOptions so the chart still boots if it ever meets a pre-JDK-24 image. New docker-smoke job starts the built image and gates docker-push, since nothing else in CI runs it.